### PR TITLE
Build RBD persistent cache plugin

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -223,6 +223,7 @@ build() {
     -DWITH_FMT_VERSION="9.0.0" \
     -DENABLE_SHARED=ON \
     -DWITH_TESTS=ON \
+    -DWITH_RBD_RWL=ON \
     -Wno-dev
 
   VERBOSE=1 make -C build legacy-option-headers


### PR DESCRIPTION
Currently `rwl_cache` plugin is not included in `ceph-libs` discribution.
It's required for https://docs.ceph.com/en/quincy/rbd/rbd-persistent-write-log-cache/
The current distribution already have [read-only](https://docs.ceph.com/en/quincy/rbd/rbd-persistent-read-only-cache/) cache plugin, but does not support read-write cache for rbd.
