### PR TITLE
Boost 1.91, Python 3.14 compatibility

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -103,6 +103,7 @@ pkgbase = ceph
 	source = ceph-20.2.0-backport-boost-190-fixes.patch
 	source = ceph-20.2.0-mgr-module-optional-notify-types.patch
 	source = ceph-20.2.0-cmake-install-fixes.patch
+	source = ceph-20.2.1-boost-191-flat-set-insert.patch
 	sha512sums = bd178ddd5efa532c90bc7633892452d49570da71cc9cb8a448048a51f4e1487a59dba05bea78cc2e6c9c75d112ed6a4f5613f5ce7f30b107682c2be620f5e1a5
 	sha512sums = 4354001c1abd9a0c385ba7bd529e3638fb6660b6a88d4e49706d4ac21c81b8e829303a20fb5445730bdac18c4865efb10bc809c1cd56d743c12aa9a52e160049
 	sha512sums = 41dbc1c395cdf9b3edf5c5d91bbc90f416b4338ad964fa3471f26a4312d3ec2a5dcebbc351a1640dc4b047b4f71aa134ac7486747e5f62980092b0176e7567f5
@@ -120,6 +121,7 @@ pkgbase = ceph
 	sha512sums = 09c8d37ad34a2a715867ebddab71e9cef8a488114f6f16fe2892d7c45609252ead8a29a8f055ff3a8253a7c96502482a1bed407922dd142ec072af55d3bcecbc
 	sha512sums = 690ddbebbbce9e0b52c9c401e668226cb0f9cea843d85ff5e5095e990df6a2905189dd9baaf21f71efc8153319a2cec16ded335bfdf40d34dbb2e33925c240ef
 	sha512sums = 14212332af61a6d055acedc8f12be6f769b49568309d5b357c40b4263d087e83b3f71f2632385c5020d487f0420f978e53fe3c3dc7c3dead75216119412fd03d
+	sha512sums = 3262a95a2a3e342d68bf01df9fa3eebfd9bb9b0d7b0780ef7f9d67d89930bc2e7494be7e5b3a50a7de7fe4f4d8e2a6d6e2cb67f133c0a53036f3cf6cd2965d82
 
 pkgname = ceph-common
 	pkgdesc = Ceph Storage common libraries and dependencies

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -104,6 +104,7 @@ pkgbase = ceph
 	source = ceph-20.2.0-mgr-module-optional-notify-types.patch
 	source = ceph-20.2.0-cmake-install-fixes.patch
 	source = ceph-20.2.1-boost-191-flat-set-insert.patch
+	source = ceph-20.2.1-mgr-asyncssh-py314.patch
 	sha512sums = bd178ddd5efa532c90bc7633892452d49570da71cc9cb8a448048a51f4e1487a59dba05bea78cc2e6c9c75d112ed6a4f5613f5ce7f30b107682c2be620f5e1a5
 	sha512sums = 4354001c1abd9a0c385ba7bd529e3638fb6660b6a88d4e49706d4ac21c81b8e829303a20fb5445730bdac18c4865efb10bc809c1cd56d743c12aa9a52e160049
 	sha512sums = 41dbc1c395cdf9b3edf5c5d91bbc90f416b4338ad964fa3471f26a4312d3ec2a5dcebbc351a1640dc4b047b4f71aa134ac7486747e5f62980092b0176e7567f5
@@ -122,6 +123,7 @@ pkgbase = ceph
 	sha512sums = 690ddbebbbce9e0b52c9c401e668226cb0f9cea843d85ff5e5095e990df6a2905189dd9baaf21f71efc8153319a2cec16ded335bfdf40d34dbb2e33925c240ef
 	sha512sums = 14212332af61a6d055acedc8f12be6f769b49568309d5b357c40b4263d087e83b3f71f2632385c5020d487f0420f978e53fe3c3dc7c3dead75216119412fd03d
 	sha512sums = 3262a95a2a3e342d68bf01df9fa3eebfd9bb9b0d7b0780ef7f9d67d89930bc2e7494be7e5b3a50a7de7fe4f4d8e2a6d6e2cb67f133c0a53036f3cf6cd2965d82
+	sha512sums = 9ffe5758a13305f355cf3f34831577f934484aa44453f143b1e52d5a70c9f74c11588a987e7b941df5b78d979e63a12a21cad8b63b18f17735235f6fb3a1f208
 
 pkgname = ceph-common
 	pkgdesc = Ceph Storage common libraries and dependencies

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -104,6 +104,12 @@ source=(
   # Fixes to a few non-configurable installation paths that do not match
   # Archlinux conventions
   'ceph-20.2.0-cmake-install-fixes.patch'
+
+  # Boost 1.91 made flat_set::insert(begin, end) ambiguous with
+  # insert(const_iterator, K&&) when the comparator is transparent. No
+  # upstream Ceph fix yet (ceph/main has the same code); local workaround
+  # uses a per-element loop instead of the range insert.
+  'ceph-20.2.1-boost-191-flat-set-insert.patch'
 )
 sha512sums=('bd178ddd5efa532c90bc7633892452d49570da71cc9cb8a448048a51f4e1487a59dba05bea78cc2e6c9c75d112ed6a4f5613f5ce7f30b107682c2be620f5e1a5'
             '4354001c1abd9a0c385ba7bd529e3638fb6660b6a88d4e49706d4ac21c81b8e829303a20fb5445730bdac18c4865efb10bc809c1cd56d743c12aa9a52e160049'
@@ -121,7 +127,8 @@ sha512sums=('bd178ddd5efa532c90bc7633892452d49570da71cc9cb8a448048a51f4e1487a59d
             '65334e1d6a94b15d28c30a2cf1eb86d40f96f4305308c451ff9b446a59fa98653400c9d5c047535375b5fc96d53dc70877eb20f8378b57516cd7292bec28c6f8'
             '09c8d37ad34a2a715867ebddab71e9cef8a488114f6f16fe2892d7c45609252ead8a29a8f055ff3a8253a7c96502482a1bed407922dd142ec072af55d3bcecbc'
             '690ddbebbbce9e0b52c9c401e668226cb0f9cea843d85ff5e5095e990df6a2905189dd9baaf21f71efc8153319a2cec16ded335bfdf40d34dbb2e33925c240ef'
-            '14212332af61a6d055acedc8f12be6f769b49568309d5b357c40b4263d087e83b3f71f2632385c5020d487f0420f978e53fe3c3dc7c3dead75216119412fd03d')
+            '14212332af61a6d055acedc8f12be6f769b49568309d5b357c40b4263d087e83b3f71f2632385c5020d487f0420f978e53fe3c3dc7c3dead75216119412fd03d'
+            '3262a95a2a3e342d68bf01df9fa3eebfd9bb9b0d7b0780ef7f9d67d89930bc2e7494be7e5b3a50a7de7fe4f4d8e2a6d6e2cb67f133c0a53036f3cf6cd2965d82')
 __version="${pkgver}-${pkgrel}"
 
 # -fno-plt causes linker errors (undefined reference to internal methods)

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -110,6 +110,11 @@ source=(
   # upstream Ceph fix yet (ceph/main has the same code); local workaround
   # uses a per-element loop instead of the range insert.
   'ceph-20.2.1-boost-191-flat-set-insert.patch'
+
+  # Bump pinned asyncssh from 2.9 (Jan 2022) to >=2.20 so cephadm tests
+  # work on Python 3.14. asyncssh 2.20.0 (Feb 2025) explicitly fixed
+  # Python 3.14 incompatibilities. No upstream Ceph fix yet.
+  'ceph-20.2.1-mgr-asyncssh-py314.patch'
 )
 sha512sums=('bd178ddd5efa532c90bc7633892452d49570da71cc9cb8a448048a51f4e1487a59dba05bea78cc2e6c9c75d112ed6a4f5613f5ce7f30b107682c2be620f5e1a5'
             '4354001c1abd9a0c385ba7bd529e3638fb6660b6a88d4e49706d4ac21c81b8e829303a20fb5445730bdac18c4865efb10bc809c1cd56d743c12aa9a52e160049'
@@ -128,7 +133,8 @@ sha512sums=('bd178ddd5efa532c90bc7633892452d49570da71cc9cb8a448048a51f4e1487a59d
             '09c8d37ad34a2a715867ebddab71e9cef8a488114f6f16fe2892d7c45609252ead8a29a8f055ff3a8253a7c96502482a1bed407922dd142ec072af55d3bcecbc'
             '690ddbebbbce9e0b52c9c401e668226cb0f9cea843d85ff5e5095e990df6a2905189dd9baaf21f71efc8153319a2cec16ded335bfdf40d34dbb2e33925c240ef'
             '14212332af61a6d055acedc8f12be6f769b49568309d5b357c40b4263d087e83b3f71f2632385c5020d487f0420f978e53fe3c3dc7c3dead75216119412fd03d'
-            '3262a95a2a3e342d68bf01df9fa3eebfd9bb9b0d7b0780ef7f9d67d89930bc2e7494be7e5b3a50a7de7fe4f4d8e2a6d6e2cb67f133c0a53036f3cf6cd2965d82')
+            '3262a95a2a3e342d68bf01df9fa3eebfd9bb9b0d7b0780ef7f9d67d89930bc2e7494be7e5b3a50a7de7fe4f4d8e2a6d6e2cb67f133c0a53036f3cf6cd2965d82'
+            '9ffe5758a13305f355cf3f34831577f934484aa44453f143b1e52d5a70c9f74c11588a987e7b941df5b78d979e63a12a21cad8b63b18f17735235f6fb3a1f208')
 __version="${pkgver}-${pkgrel}"
 
 # -fno-plt causes linker errors (undefined reference to internal methods)

--- a/ceph-20.2.1-boost-191-flat-set-insert.patch
+++ b/ceph-20.2.1-boost-191-flat-set-insert.patch
@@ -1,0 +1,109 @@
+Boost 1.91 changed Boost.Container's flat_set such that
+`insert(InputIterator, InputIterator)` is now ambiguous with
+`insert(const_iterator, K&&)` when the comparator declares
+`is_transparent`. The transparent-K overload now also accepts iterator
+types as K, so the compiler cannot pick between the single-element
+hint-insert and the range-insert.
+
+Workaround: loop over the source range and call the single-arg
+`insert(value)` overload, which is unambiguous.
+
+This patch covers every range-insert in the tree against
+`rgw::zone_features::set` (the only transparent flat_set comparator,
+verified via GitHub code search of ceph/ceph for `is_transparent
+flat_set`). Some of these sites compile fine with iterator types other
+than `flat_set::const_iterator`, but rewriting them all keeps the
+behavior consistent and prevents future churn.
+
+No upstream Ceph fix exists yet; ceph/main has the same code.
+
+diff --git a/src/rgw/driver/json_config/store.cc b/src/rgw/driver/json_config/store.cc
+--- a/src/rgw/driver/json_config/store.cc
++++ b/src/rgw/driver/json_config/store.cc
+@@ -149,8 +149,9 @@
+       throw std::system_error(-r, std::system_category());
+     }
+ 
+-    config.zonegroup.enabled_features.insert(rgw::zone_features::enabled.begin(),
+-                                             rgw::zone_features::enabled.end());
++    for (const auto& feature : rgw::zone_features::enabled) {
++      config.zonegroup.enabled_features.insert(std::string{feature});
++    }
+   }
+ 
+   // insert the default placement target if it doesn't exist
+diff --git a/src/rgw/driver/rados/rgw_zone.cc b/src/rgw/driver/rados/rgw_zone.cc
+--- a/src/rgw/driver/rados/rgw_zone.cc
++++ b/src/rgw/driver/rados/rgw_zone.cc
+@@ -82,11 +82,13 @@
+   master_zone = default_zone.id;
+ 
+   // initialize supported zone features
+-  default_zone.supported_features.insert(rgw::zone_features::supported.begin(),
+-                                         rgw::zone_features::supported.end());
++  for (const auto& feature : rgw::zone_features::supported) {
++    default_zone.supported_features.insert(std::string{feature});
++  }
+   // enable default zonegroup features
+-  enabled_features.insert(rgw::zone_features::enabled.begin(),
+-                          rgw::zone_features::enabled.end());
++  for (const auto& feature : rgw::zone_features::enabled) {
++    enabled_features.insert(std::string{feature});
++  }
+   
+   r = create(dpp, y);
+   if (r < 0 && r != -EEXIST) {
+@@ -195,8 +197,9 @@
+     zone.sync_from.erase(rm);
+   }
+ 
+-  zone.supported_features.insert(enable_features.begin(),
+-                                 enable_features.end());
++  for (const auto& feature : enable_features) {
++    zone.supported_features.insert(feature);
++  }
+ 
+   for (const auto& feature : disable_features) {
+     if (enabled_features.contains(feature)) {
+@@ -873,8 +876,9 @@
+   info.is_master = true;
+ 
+   // enable all supported features
+-  info.enabled_features.insert(rgw::zone_features::enabled.begin(),
+-                               rgw::zone_features::enabled.end());
++  for (const auto& feature : rgw::zone_features::enabled) {
++    info.enabled_features.insert(std::string{feature});
++  }
+ 
+   // add the zone to the zonegroup
+   bool is_master = true;
+diff --git a/src/rgw/radosgw-admin/radosgw-admin.cc b/src/rgw/radosgw-admin/radosgw-admin.cc
+--- a/src/rgw/radosgw-admin/radosgw-admin.cc
++++ b/src/rgw/radosgw-admin/radosgw-admin.cc
+@@ -5553,8 +5553,9 @@
+ 
+         zonegroup.enabled_features = enable_features;
+         if (zonegroup.enabled_features.empty()) { // enable features by default
+-          zonegroup.enabled_features.insert(rgw::zone_features::enabled.begin(),
+-                                            rgw::zone_features::enabled.end());
++          for (const auto& feature : rgw::zone_features::enabled) {
++            zonegroup.enabled_features.insert(std::string{feature});
++          }
+         }
+         for (const auto& feature : disable_features) {
+           auto i = zonegroup.enabled_features.find(feature);
+diff --git a/src/rgw/rgw_zone.cc b/src/rgw/rgw_zone.cc
+--- a/src/rgw/rgw_zone.cc
++++ b/src/rgw/rgw_zone.cc
+@@ -1423,8 +1423,9 @@
+   }
+ 
+   // add/remove supported features
+-  zone.supported_features.insert(enable_features.begin(),
+-                                 enable_features.end());
++  for (const auto& feature : enable_features) {
++    zone.supported_features.insert(feature);
++  }
+ 
+   for (const auto& feature : disable_features) {
+     if (zonegroup.enabled_features.contains(feature)) {

--- a/ceph-20.2.1-mgr-asyncssh-py314.patch
+++ b/ceph-20.2.1-mgr-asyncssh-py314.patch
@@ -1,0 +1,28 @@
+Ceph 20.2.1's mgr requirements pin `asyncssh==2.9` (frozen since
+2022-01-25, ceph/ceph dd09127ec4979ee27708d1aab44cc13a7bb3b2e6). On
+Python 3.14, that version of asyncssh's `_RecordMeta` metaclass
+(asyncssh/misc.py) fails to construct `SSHCompletedProcess` instances:
+
+  AttributeError: 'SSHCompletedProcess' object has no attribute
+                  'returncode' and no __dict__ for setting new attributes
+
+The cause is asyncssh 2.9 setting `__slots__` to a `dict` of field
+defaults, which Python 3.14 no longer accepts as a slot specification.
+asyncssh 2.20.0 (2025-02-17) fixes this; see the upstream changelog
+entry "Fixed a couple of issues with Python 3.14".
+
+This breaks `cephadm/tests/test_ssh.py` under run-tox-mgr. The bump is
+otherwise behavior-preserving (no API changes between 2.9 and 2.20+
+that cephadm uses).
+
+No upstream Ceph fix exists yet; ceph/main has the same pin.
+
+diff --git a/src/pybind/mgr/requirements.txt b/src/pybind/mgr/requirements.txt
+--- a/src/pybind/mgr/requirements.txt
++++ b/src/pybind/mgr/requirements.txt
+@@ -1,4 +1,4 @@
+ -rrequirements-required.txt
+-asyncssh==2.9
++asyncssh>=2.20
+ kubernetes
+ urllib3==1.26.15


### PR DESCRIPTION
Two patches, justification for each is documented inline.

All of the fixes here are from Claude, so take with a grain of salt.